### PR TITLE
fix: restore truncated identifiers and missing imports (NameError in process_document, prepare_dataset, plugin discovery)

### DIFF
--- a/multimind/document_loader/document_loader.py
+++ b/multimind/document_loader/document_loader.py
@@ -3,6 +3,7 @@ Enhanced document loading with support for multiple formats and sources.
 """
 
 import asyncio
+import io
 import json
 import logging
 from dataclasses import dataclass

--- a/multimind/document_processing/document.py
+++ b/multimind/document_processing/document.py
@@ -139,10 +139,10 @@ class DocumentProcessor:
         """
         # Handle input types
         if isinstance(document, str):
-            text = documen
+            text = document
             doc_metadata = metadata or {}
         else:
-            text = document.tex
+            text = document.text
             doc_metadata = {**document.metadata, **(metadata or {})}
 
         # Clean tex

--- a/multimind/fine_tuning/peft_methods.py
+++ b/multimind/fine_tuning/peft_methods.py
@@ -380,7 +380,7 @@ class PEFTTuner:
             tokenize_function, batched=True, remove_columns=dataset.column_names
         )
 
-        return tokenized_datase
+        return tokenized_dataset
 
     def train(
         self,

--- a/multimind/fine_tuning/unified_peft.py
+++ b/multimind/fine_tuning/unified_peft.py
@@ -250,7 +250,7 @@ class UniPELTTuner:
             tokenize_function, batched=True, remove_columns=dataset.column_names
         )
 
-        return tokenized_datase
+        return tokenized_dataset
 
     def train(
         self,
@@ -439,7 +439,7 @@ class MAMAdapterTuner:
             tokenize_function, batched=True, remove_columns=dataset.column_names
         )
 
-        return tokenized_datase
+        return tokenized_dataset
 
     def train(
         self,

--- a/multimind/vector_store/vector_store_enhanced.py
+++ b/multimind/vector_store/vector_store_enhanced.py
@@ -9,6 +9,7 @@ Enhanced vector store module with advanced features:
 """
 
 import asyncio
+import importlib.util
 import json
 import logging
 import sqlite3


### PR DESCRIPTION
## What does this PR do?

Fixes a handful of identifiers that lost their last character, plus two missing stdlib imports. Each one makes the affected code path fail at runtime.

| File | Problem | Effect |
|---|---|---|
| `multimind/document_processing/document.py` | `text = documen` / `text = document.tex` | `DocumentProcessor.process_document` always raises (`NameError` for `str` input, `AttributeError` for `Document` input), so `process_file` / `process_text` / `process_url` fail too |
| `multimind/fine_tuning/peft_methods.py` | `return tokenized_datase` | `prepare_dataset` raises `NameError` |
| `multimind/fine_tuning/unified_peft.py` (2×) | `return tokenized_datase` | same |
| `multimind/vector_store/vector_store_enhanced.py` | `importlib.util` used, never imported | the `NameError` is caught by the `except`, so every plugin in `discover_plugins` gets logged as a failed load |
| `multimind/document_loader/document_loader.py` | `io.BytesIO` used, never imported | loading a PDF from a URL raises `NameError` |

All of these were flagged by `pyflakes` as `undefined name`. The repo's ruff config doesn't catch them because it doesn't enable F821.

### Before / after

```python
p = DocumentProcessor()
p.process_document("hello world. second sentence.")
p.process_document(Document(text="obj text here.", metadata={"k": 1}))
```

Before:
```
ERR NameError name 'documen' is not defined
ERR AttributeError 'Document' object has no attribute 'tex'
```
After:
```
OK [('hello world. second sentence.', {'chunk_index': 0, 'total_chunks': 1})]
OK [('obj text here.', {'k': 1, 'chunk_index': 0, 'total_chunks': 1})]
```

## Checklist

- [x] No breaking changes (7 lines added, 5 removed, no behaviour change beyond the fixes above)
- [x] `ruff check` on the changed files: no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
